### PR TITLE
Remove extra `skyCamera.transform.rotation` set

### DIFF
--- a/NightShift/SkyboxManager.cs
+++ b/NightShift/SkyboxManager.cs
@@ -50,7 +50,6 @@ namespace NightShift
         {
             if (skyCamera)
             {
-                skyCamera.transform.position = mainSceneryCamera.transform.position;
                 skyCamera.transform.rotation = mainSceneryCamera.transform.rotation;
                 // Rotate this correctly for SPH
                 if (EditorDriver.editorFacility == EditorFacility.VAB)


### PR DESCRIPTION
Hi, I was curious how this mod worked, and while I was browsing the code I noticed a line that seemed to be duplicated:

https://github.com/coldrifting/NightShift/blob/f0798d0adadbb02d13c14ad9717d74b64ea665ad/NightShift/SkyboxManager.cs#L53-L54

It's possible that this is intentional, but that seems unlikely enough to attempt a pull request to remove it.

Cheers and good luck with the mod!